### PR TITLE
Fix error if not defined tasks

### DIFF
--- a/src/tasks/default.js
+++ b/src/tasks/default.js
@@ -14,5 +14,9 @@ import inSequence from 'run-sequence';
  */
 
 gulp.task('default', function() {
-    inSequence.apply(this, Elixir.tasks.names());
+    let tasks = Elixir.tasks.names();
+    
+    if (tasks.length) {
+        inSequence.apply(this, tasks);
+    }
 });


### PR DESCRIPTION
If you not set tasks the task default accuses error in the plugin 'run-sequence '

```js
var elixir = require("laravel-elixir");

elixir(function(mix) {
    // error
});
```